### PR TITLE
Encapsulate working directory with ". 

### DIFF
--- a/src/SharpServer/Ftp/FtpClientConnection.cs
+++ b/src/SharpServer/Ftp/FtpClientConnection.cs
@@ -1030,6 +1030,9 @@ namespace SharpServer.Ftp
                 current = "/";
             }
 
+            //Encapsulate working directory with ". Needed in order to support folders with spaces in them (in Filezilla and other FTP Clients).
+            current = "\"" + current + "\"";
+
             return GetResponse(FtpResponses.CURRENT_DIRECTORY.SetData(current));
         }
 


### PR DESCRIPTION
Missing implementation of RFC 959. Makes FileZilla and other clients unable to download files/folder with spaces in the names.

**From RFC 959:**

_Essentially because the PWD command returns the same type of information as the successful MKD command, the successful PWD command uses the 257 reply code as well._

_....upon successful completion of an MKD command, the server should return a line of the form:_

`257<space>"<directory-name>"<space><commentary>`

_That is, the server will tell the user what string to use when referring to the created directory. The directory name can contain any character; embedded double-quotes should be escaped by double-quotes (the "quote-doubling" convention)."_
